### PR TITLE
Adds CMakeLists.txt to the project, removes ValueTree & references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,9 @@ JuceLibraryCode/
 *.exe
 *.out
 *.app
+
+# CLion config and build products
+.idea/
+cmake-build-debug/
+cmake-build-release/
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,74 @@
+cmake_minimum_required(VERSION 3.15)
+
+# Project name and version
+project(JUCE_GRAPHICS_SHOP VERSION 0.1.0)
+
+# Use FetchContent to fetch JUCE from GitHub
+include(FetchContent)
+
+FetchContent_Declare(
+    JUCE
+    GIT_REPOSITORY https://github.com/juce-framework/JUCE.git
+    GIT_TAG        7.0.12 # Replace with the desired version or branch
+)
+
+FetchContent_MakeAvailable(JUCE)
+
+# Add GUI app
+juce_add_gui_app(JUCE_GRAPHICS_SHOP
+    # Icon files
+    ICON_BIG     Source/F128.png
+    ICON_SMALL   Source/F64.png
+)
+
+# Add JUCE modules
+target_link_libraries(JUCE_GRAPHICS_SHOP
+    PRIVATE
+        juce::juce_core
+        juce::juce_data_structures
+        juce::juce_events
+        juce::juce_graphics
+        juce::juce_gui_basics
+        juce::juce_gui_extra
+)
+
+juce_generate_juce_header(JUCE_GRAPHICS_SHOP)
+
+# Add source files
+target_sources(JUCE_GRAPHICS_SHOP
+    PRIVATE
+        Source/MainMenuBarModel.cpp
+        Source/RectangleController.cpp
+        Source/TransformSection.cpp
+        Source/GradientSection.cpp
+        Source/ColourSection.cpp
+        Source/ComponentController.cpp
+        Source/Main.cpp
+        Source/MainComponent.cpp
+)
+
+# Add include directories
+target_include_directories(JUCE_GRAPHICS_SHOP
+    PRIVATE
+        ${JUCE_SOURCE_DIR}/modules
+        ${CMAKE_CURRENT_SOURCE_DIR}/Source
+)
+
+
+# Set compiler options
+target_compile_definitions(JUCE_GRAPHICS_SHOP
+    PRIVATE
+        JUCE_STRICT_REFCOUNTEDPOINTER=1
+)
+
+# Debug/Release configurations
+set_target_properties(JUCE_GRAPHICS_SHOP PROPERTIES
+    CMAKE_CXX_STANDARD 17
+    CMAKE_CXX_STANDARD_REQUIRED YES
+    CMAKE_POSITION_INDEPENDENT_CODE ON
+)
+
+# Debug
+message(STATUS "JUCE modules available: ${JUCE_MODULE_AVAILABLE_juce_gui_basics}")
+message(STATUS "Linking to juce_gui_basics: ${JUCE_LINK_LIBRARIES}")
+

--- a/Source/MainComponent.cpp
+++ b/Source/MainComponent.cpp
@@ -250,7 +250,7 @@ ValueTree MainComponent::getNewComponentTree(int layerID) {
 	return componentTree;
 }
 
-ValueTree& MainComponent::getComponentTree(int layerID) {
+ValueTree MainComponent::getComponentTree(int layerID) {
 	return m_masterTree.getChildWithName(COMPONENTS_TREE).getChildWithProperty(ID, layerID);
 }
 

--- a/Source/MainComponent.h
+++ b/Source/MainComponent.h
@@ -37,7 +37,7 @@ private:
     void initMenuBar();
     void initMasterTree();
 	ValueTree getNewComponentTree(int layerID);
-    ValueTree& getComponentTree(int id);
+    ValueTree getComponentTree(int id);
 	void setComponentControllersViewedComponent(int id);
     void deleteComponent(int layerID);
     void setLayerZOrder(Array<int> layerIDs);

--- a/Source/RectangleController.cpp
+++ b/Source/RectangleController.cpp
@@ -10,9 +10,9 @@
 
 #include "RectangleController.h"
 RectangleController::RectangleController(int rowID, ValueTree& masterTree) {
-	ValueTree& componentsTree = masterTree.getChildWithName(COMPONENTS_TREE);
-	ValueTree& componentTree = componentsTree.getChildWithProperty(ID, rowID);
-	ValueTree& rectangleTree = componentTree.getChildWithName(RECTANGLE_TREE);
+	ValueTree componentsTree = masterTree.getChildWithName(COMPONENTS_TREE);
+	ValueTree componentTree = componentsTree.getChildWithProperty(ID, rowID);
+	ValueTree rectangleTree = componentTree.getChildWithName(RECTANGLE_TREE);
 
 	addAndMakeVisible(isRoundedToggle);
 

--- a/Source/TransformSection.cpp
+++ b/Source/TransformSection.cpp
@@ -11,9 +11,9 @@
 #include "TransformSection.h"
 
 TransformSection::TransformSection(int rowID, ValueTree& masterTree) {
-	ValueTree& componentsTree = masterTree.getChildWithName(COMPONENTS_TREE);
-	ValueTree& componentTree = componentsTree.getChildWithProperty(ID, rowID);
-	ValueTree& transformTree = componentTree.getChildWithName(TRANSFORM_TREE);
+	ValueTree componentsTree = masterTree.getChildWithName(COMPONENTS_TREE);
+	ValueTree componentTree = componentsTree.getChildWithProperty(ID, rowID);
+	ValueTree transformTree = componentTree.getChildWithName(TRANSFORM_TREE);
 
 	//StringArray sliderIDs = StringArray{ X,Y,WIDTH,HEIGHT };
 	Array sliderIDs{ X,Y,WIDTH,HEIGHT };


### PR DESCRIPTION
I added a CMakeLists.txt to build the project, as well as the requisite .gitignore lines needed to make the project usable in CLion.

I also converted the use of ValueTree& references to copies instead, as otherwise it would produce this error when building, e.g.:

```
Source/TransformSection.cpp:16:13: error: non-const lvalue reference to type 'ValueTree' cannot bind to a temporary of type 'ValueTree'
        ValueTree& transformTree = componentTree.getChildWithName(TRANSFORM_TREE);
```

I originally tried marking the _ValueTree&_ refs as **const**, but this led to crashing at runtime which I didn't feel should have been necessary to further debug.  Using ValueTree copies instead results in a functioning application.

Tested on MacOS Ventura 13.6.7 with:

```
set(CMAKE_CXX_COMPILER_ID "AppleClang")
set(CMAKE_CXX_COMPILER_VERSION "15.0.0.15000100")

```